### PR TITLE
Fix #9 - add `Emoji::aliases`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl Emoji {
             .find(|emoji| emoji.skin_tone().unwrap() == skin_tone)
     }
 
-    /// Returns this emoji's GitHub shortcode.
+    /// Returns this emoji's first GitHub shortcode.
     ///
     /// See [gemoji] for more information.
     ///
@@ -261,19 +261,22 @@ impl Emoji {
         self.aliases.and_then(|aliases| aliases.first().copied())
     }
 
-    /// Returns an iterator over this emoji's GitHub shortcode and aliases.
+    /// Returns an iterator over this emoji's GitHub shortcodes.
     ///
     /// See [gemoji] for more information.
     ///
     /// # Examples
     ///
     /// ```
-    /// let thinking = emojis::get("🤔").unwrap();
-    /// assert_eq!(thinking.aliases().next().unwrap(), "thinking");
+    /// let laughing = emojis::get("😆").unwrap();
+    /// assert_eq!(
+    ///     laughing.shortcodes().collect::<Vec<&str>>(),
+    ///     vec!["laughing", "satisfied"]
+    /// );
     /// ```
     ///
     /// [gemoji]: https://github.com/github/gemoji
-    pub fn aliases(&self) -> impl Iterator<Item = &str> {
+    pub fn shortcodes(&self) -> impl Iterator<Item = &'static str> {
         self.aliases.into_iter().flatten().copied()
     }
 }
@@ -457,9 +460,9 @@ mod tests {
     }
 
     #[test]
-    fn aliases() {
+    fn shortcodes() {
         for emoji in iter() {
-            assert_eq!(emoji.shortcode(), emoji.aliases().next());
+            assert_eq!(emoji.shortcode(), emoji.shortcodes().next());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl Emoji {
     /// ```
     ///
     /// [gemoji]: https://github.com/github/gemoji
-    pub fn aliases(&self) -> impl Iterator<Item = &str> + '_ {
+    pub fn aliases(&self) -> impl Iterator<Item = &str> {
         self.aliases.into_iter().flatten().copied()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,22 @@ impl Emoji {
     pub fn shortcode(&self) -> Option<&str> {
         self.aliases.and_then(|aliases| aliases.first().copied())
     }
+
+    /// Returns an iterator over this emoji's GitHub shortcode and aliases.
+    ///
+    /// See [gemoji] for more information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let thinking = emojis::get("🤔").unwrap();
+    /// assert_eq!(thinking.aliases().next().unwrap(), "thinking");
+    /// ```
+    ///
+    /// [gemoji]: https://github.com/github/gemoji
+    pub fn aliases(&self) -> impl Iterator<Item = &str> + '_ {
+        self.aliases.into_iter().flatten().copied()
+    }
 }
 
 impl cmp::PartialEq<Emoji> for Emoji {
@@ -437,6 +453,13 @@ mod tests {
                     assert!(emoji.skin_tones().is_none());
                 }
             }
+        }
+    }
+
+    #[test]
+    fn aliases() {
+        for emoji in iter() {
+            assert_eq!(emoji.shortcode(), emoji.aliases().next());
         }
     }
 }


### PR DESCRIPTION
Fixes #9 with a new public API, `Emoji::aliases`, that iterates *all* the aliases.